### PR TITLE
Add missing header file for aarch64 transformer-engine build

### DIFF
--- a/packages/transformer-engine/build.sh
+++ b/packages/transformer-engine/build.sh
@@ -14,10 +14,6 @@
 # limitations under the License.
 
 # https://github.com/NVIDIA/TransformerEngine?tab=readme-ov-file#pip-installation
-if [[ "$(uname -m)" == "aarch64" && -z "${TORCH_CUDA_ARCH_LIST:-}" ]]; then
-	export TORCH_CUDA_ARCH_LIST="8.7;9.0"
-fi
-
 export NVTE_FRAMEWORK=pytorch
 export NVTE_CUDA_ARCHS="${TORCH_CUDA_ARCH_LIST//./}"
 


### PR DESCRIPTION
`cuda_cmake_macros.h` header file is required for transformer-engine wheel build. It was missing on aarch64 - workaround is to copy file from x86_64.

Downloading pytorch via pip doesn't fetch all the C++ header files which are usually not necessary, but required for some extensions