### PR TITLE
Add sageattention wheel with latest commit

### DIFF
--- a/docs/v1.4.0/cu128_torch27/simple/sageattention/index.html
+++ b/docs/v1.4.0/cu128_torch27/simple/sageattention/index.html
@@ -2,5 +2,6 @@
 <html>
 <body>
 <a href='https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.4.0/sageattention-2.2.0%2Bcu128.torch27-cp310-cp310-linux_x86_64.whl#sha256=31bc9b7ffb6a1836ddd98b39397fa3fcb65af7d5996ce5880247ffcc93000533'>sageattention-2.2.0+cu128.torch27-cp310-cp310-linux_x86_64.whl</a><br>
+<a href='https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.4.0/sageattention-2.2.0.dev1%2Bcu128.torch27-cp310-cp310-linux_aarch64.whl#sha256=9318d28105b924760901d7d3d304b28f7cd8d3ea1afff73c29be4c42826a8204'>sageattention-2.2.0.dev1+cu128.torch27-cp310-cp310-linux_aarch64.whl</a><br>
 </body>
 </html>

--- a/docs/v1.4.0/simple/sageattention/index.html
+++ b/docs/v1.4.0/simple/sageattention/index.html
@@ -4,5 +4,6 @@
 <a href='https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.4.0/sageattention-2.2.0%2Bcu128.torch27-cp310-cp310-linux_x86_64.whl#sha256=31bc9b7ffb6a1836ddd98b39397fa3fcb65af7d5996ce5880247ffcc93000533'>sageattention-2.2.0+cu128.torch27-cp310-cp310-linux_x86_64.whl</a><br>
 <a href='https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.4.0/sageattention-2.2.0%2Bcu128.torch29-cp312-cp312-linux_x86_64.whl#sha256=71be3ab33e281907ed5fb7decf55ef818067ebf47e46419a57ccb2abb6399c76'>sageattention-2.2.0+cu128.torch29-cp312-cp312-linux_x86_64.whl</a><br>
 <a href='https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.4.0/sageattention-2.2.0%2Bcu130.torch29-cp312-cp312-linux_x86_64.whl#sha256=1efca66235a13e2d6a7744732686c8398363975ba4612f7d6d56fd9444598d34'>sageattention-2.2.0+cu130.torch29-cp312-cp312-linux_x86_64.whl</a><br>
+<a href='https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.4.0/sageattention-2.2.0.dev1%2Bcu128.torch27-cp310-cp310-linux_aarch64.whl#sha256=9318d28105b924760901d7d3d304b28f7cd8d3ea1afff73c29be4c42826a8204'>sageattention-2.2.0.dev1+cu128.torch27-cp310-cp310-linux_aarch64.whl</a><br>
 </body>
 </html>

--- a/packages/sageattention/build.sh
+++ b/packages/sageattention/build.sh
@@ -18,6 +18,15 @@ export EXT_PARALLEL=4
 export NVCC_APPEND_FLAGS="--threads 8"
 export MAX_JOBS=32
 
+case "$PACKAGE_VERSION" in
+2.2.0.dev1)
+	PACKAGE_REVISION="d1a57a546c3d395b1ffcbeecc66d81db76f3b4b5"
+	;;
+*)
+	PACKAGE_REVISION="v${PACKAGE_VERSION}"
+	;;
+esac
+
 # TODO(joallen):
 export TORCH_CUDA_ARCH_LIST='9.0' # Hopper
 # export TORCH_CUDA_ARCH_LIST='10.0;12.0' # Blackwell
@@ -28,5 +37,5 @@ pip wheel \
 	--no-build-isolation \
 	--check-build-dependencies \
 	--wheel-dir="${OUTPUT_DIR}" \
-	"git+https://github.com/thu-ml/SageAttention.git@v${PACKAGE_VERSION}" \
+	"git+https://github.com/thu-ml/SageAttention.git@${PACKAGE_REVISION}" \
 	"$@"


### PR DESCRIPTION
There's a H100 kernel bug that was fixed post-2.2.0 release. Adding option to fetch sageattention via commit and build new wheel with the patch. 

Bug: https://github.com/thu-ml/SageAttention/issues/288