### PR TITLE
Optimize Flash attention3 custom wheel

### DIFF
--- a/docs/v1.2.0/cu128_torch27/simple/flash-attn-3-nv/index.html
+++ b/docs/v1.2.0/cu128_torch27/simple/flash-attn-3-nv/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
 <body>
-<a href='https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.2.0/flash_attn_3_nv-1.0.1%2Bcu128.torch27-cp39-abi3-linux_x86_64.whl#sha256=f2a43f0c905d3890be38c66890e0c0eb33efc1f9327d10f538dc3075cdd253fb'>flash_attn_3_nv-1.0.1+cu128.torch27-cp39-abi3-linux_x86_64.whl</a><br>
+<a href='https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.2.0/flash_attn_3_nv-1.0.1%2Bcu128.torch27-cp39-abi3-linux_x86_64.whl#sha256=b7b93cde91b958b164471a05628bc4676191e5b318211ad09175b347158fcb36'>flash_attn_3_nv-1.0.1+cu128.torch27-cp39-abi3-linux_x86_64.whl</a><br>
 </body>
 </html>

--- a/docs/v1.2.0/simple/flash-attn-3-nv/index.html
+++ b/docs/v1.2.0/simple/flash-attn-3-nv/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
 <body>
-<a href='https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.2.0/flash_attn_3_nv-1.0.1%2Bcu128.torch27-cp39-abi3-linux_x86_64.whl#sha256=f2a43f0c905d3890be38c66890e0c0eb33efc1f9327d10f538dc3075cdd253fb'>flash_attn_3_nv-1.0.1+cu128.torch27-cp39-abi3-linux_x86_64.whl</a><br>
+<a href='https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.2.0/flash_attn_3_nv-1.0.1%2Bcu128.torch27-cp39-abi3-linux_x86_64.whl#sha256=b7b93cde91b958b164471a05628bc4676191e5b318211ad09175b347158fcb36'>flash_attn_3_nv-1.0.1+cu128.torch27-cp39-abi3-linux_x86_64.whl</a><br>
 </body>
 </html>

--- a/packages/flash-attn-3-nv/build.sh
+++ b/packages/flash-attn-3-nv/build.sh
@@ -15,6 +15,7 @@
 
 # https://github.com/Dao-AILab/flash-attention?tab=readme-ov-file#installation-and-features
 export MAX_JOBS=${MAX_JOBS:-$(($(nproc) / 4))}
+export FLASH_ATTENTION_DISABLE_SM80=TRUE
 
 # https://github.com/Dao-AILab/flash-attention/blob/main/hopper/setup.py
 export FLASH_ATTENTION_FORCE_BUILD=TRUE


### PR DESCRIPTION
- Remove sm_80 architectures when building since we are only using for sm_90 architectures
- Manually setting ` TORCH_CUDA_ARCH_LIST=9.0` did not work since it is overriden in [setup.py](https://github.com/alihassanijr/flash_attn_3_nv/blob/main/setup.py) of the fa3 fork
- Reduced wheel size from 420MB -> 266 MB