### PR TITLE
Add cosmos-nvfp4 0.1.0 (cu130.torch210, sm100/sm103) to v1.5.0 index

### DIFF
--- a/docs/v1.5.0/cosmos-nvfp4/index.html
+++ b/docs/v1.5.0/cosmos-nvfp4/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<a href='https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.5.0/cosmos_nvfp4-0.1.0%2Bcu130.torch210.sm100-cp313-cp313-linux_aarch64.whl#sha256=d33d7680e70d673062970de2a4d498238a74ca38a5908583176a344ecd157985'>cosmos_nvfp4-0.1.0+cu130.torch210.sm100-cp313-cp313-linux_aarch64.whl</a><br>
+<a href='https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.5.0/cosmos_nvfp4-0.1.0%2Bcu130.torch210.sm103-cp313-cp313-linux_aarch64.whl#sha256=94063490da0cf02beb78843562408c4f33aa53dc05a0e1134b9782b0a4b39d60'>cosmos_nvfp4-0.1.0+cu130.torch210.sm103-cp313-cp313-linux_aarch64.whl</a><br>
+</body>
+</html>

--- a/docs/v1.5.0/index.html
+++ b/docs/v1.5.0/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <body>
+<a href='cosmos-nvfp4/'>cosmos-nvfp4</a><br>
 <a href='decord/'>decord</a><br>
 <a href='flash-attn/'>flash-attn</a><br>
 <a href='flash-attn-3-nv/'>flash-attn-3-nv</a><br>


### PR DESCRIPTION
Adds **cosmos-nvfp4** to the v1.5.0 index — the cosmos3 NVFP4 FP4-GEMM + activation-quantize CUDA
kernels packaged as a pre-built wheel (per the discussion with @Liang Feng about pulling these out
of the cosmos3 inference package so it stays free of on-the-fly native builds).

The two aarch64 wheels are already uploaded to the **v1.5.0 release** (cu130 / torch 2.10 / py3.13),
following the existing local-version naming convention:
- `cosmos_nvfp4-0.1.0+cu130.torch210.sm100` — GB200 / B200 (sm_100a); validated: imports + registers `torch.ops.cosmos3_fp4.*`
- `cosmos_nvfp4-0.1.0+cu130.torch210.sm103` — GB300 / B300 (sm_103a); experimental: compiles + correct SASS, not yet run on GB300

This PR adds the matching PEP 503 index entry (`docs/v1.5.0/cosmos-nvfp4/index.html` + one line in the
top-level index). The URLs resolve against the uploaded release assets (HTTP 200), so it's ready to
merge. Apache-2.0, built on NVIDIA CUTLASS (BSD-3-Clause).
