### PR TITLE
natten: add gb300 x86_64 wheel to v1.5.0 index

### DIFF
--- a/docs/v1.5.0/natten/index.html
+++ b/docs/v1.5.0/natten/index.html
@@ -10,5 +10,6 @@
 <a href='https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.5.0/natten-0.21.6.dev6%2Bcu130.torch210-cp313-cp313-linux_aarch64.whl#sha256=d157abf86d3f01aa683ef6637abce4f1fdf2b7aa86b5af52736e5d53e9c42da5'>natten-0.21.6.dev6+cu130.torch210-cp313-cp313-linux_aarch64.whl</a><br>
 <a href='https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.5.0/natten-0.21.6.dev6%2Bcu130.torch210-cp313-cp313-linux_x86_64.whl#sha256=13d81645a33e58500c33f4c8840c992cab1bf43b2f476b96e7a70c3864906511'>natten-0.21.6.dev6+cu130.torch210-cp313-cp313-linux_x86_64.whl</a><br>
 <a href='https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.5.0/natten-0.21.6.dev6%2Bcu130.torch210.gb300-cp313-cp313-linux_aarch64.whl#sha256=cd63a31be0ea73c3f5d8bded442508e02a74fc9827f56f92b89314498a2fde9b'>natten-0.21.6.dev6+cu130.torch210.gb300-cp313-cp313-linux_aarch64.whl</a><br>
+<a href='https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.5.0/natten-0.21.6.dev6%2Bcu130.torch210.gb300-cp313-cp313-linux_x86_64.whl#sha256=04ace5d591b2775149d7a9adc8f3e6099b18fedad364c48e70b4a998ee598b9c'>natten-0.21.6.dev6+cu130.torch210.gb300-cp313-cp313-linux_x86_64.whl</a><br>
 </body>
 </html>


### PR DESCRIPTION
Companion to #58 (aarch64). Adds the sm_103 (Blackwell Ultra / GB300) **x86_64** build of NATTEN `0.21.6.dev6` to the v1.5.0 index.

## Changes
- Registers `natten-0.21.6.dev6+cu130.torch210.gb300-cp313-cp313-linux_x86_64.whl` in `docs/v1.5.0/natten/index.html` (sha256 `04ace5d591b2775149d7a9adc8f3e6099b18fedad364c48e70b4a998ee598b9c`).

The build-infra changes (`LOCAL_VERSION_SUFFIX`, `NATTEN_CUDA_ARCH` += `10.3`) already landed in #58, so this PR only adds the index entry.

## Build
- Source: NATTEN `0.21.6.dev6` (`07c82f5`)
- CUDA 13.0.2 + `torch==2.10.0+cu130`, python 3.13
- `NATTEN_CUDA_ARCH="8.0;8.6;9.0;10.0;12.0;10.3"` -> NATTEN maps `10.3 -> sm_103a`

## Verification
- `cuobjdump libnatten.so` contains `sm_103a` (alongside sm_80/86/90a/100a/120)
- Ran `na2d` on a B300 (sm_103): completes, no "no kernel image" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)